### PR TITLE
add support for custom login handler via extension point

### DIFF
--- a/src/_login_form.html
+++ b/src/_login_form.html
@@ -1,4 +1,4 @@
-<form action="/login" method="post">
+<form class="form-signin" action="/login" method="post">
   <div class="form-group">
     <label class="control-label" for="login_username">Username</label>
     <input type="text" class="form-control" id="login_username" placeholder="Username" required="required" autofocus="autofocus" autocomplete="username">

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,17 @@
+import {IPlugin, IPluginDesc} from 'phovea_core/src/plugin';
+
+export const EXTENSION_POINT_CUSTOMIZED_LOGIN_FORM = 'securityCustomizedLoginForm';
+
+export interface ICustomizedLoginFormPluginDesc extends IPluginDesc {
+  template?: string;
+}
+
+
+export interface ICustomizedLoginFormPlugin extends IPlugin {
+  /**
+   * underlying plugin description
+   */
+  readonly desc: ICustomizedLoginFormPluginDesc;
+
+  factory(loginMenu: HTMLElement, loginDialog: HTMLElement): void;
+}


### PR DESCRIPTION
integrate an option for login menu customizer extensions

i.e an extension point: `securityCustomizedLoginForm` that allow to specify an alternative login form + initializer

as used by https://github.com/datavisyn/phovea_security_store_generated